### PR TITLE
chore: Update Github Actions workflow

### DIFF
--- a/.github/workflows/deploy-to-render.yml
+++ b/.github/workflows/deploy-to-render.yml
@@ -18,12 +18,6 @@ jobs:
         with: 
           node-version: '17'
 
-      - name: install dependencies
-        run: npm install
-
-      - name: Build
-        run: npm run build
-
       - name: Deploy to Render
         run: |
           curl -X POST \


### PR DESCRIPTION
- Removed the "Build" step from the workflow as build artifacts are already pushed.
- Removed the "Install Backend Dependencies" step to skip dependency installation.
- Workflow now focuses on deploying to Render without reinstalling existing dependencies.
- Workflow now deploys existing build artifacts directly to Render.